### PR TITLE
Use the main bundle by default

### DIFF
--- a/SwiftR/SwiftR.swift
+++ b/SwiftR/SwiftR.swift
@@ -57,7 +57,7 @@ public class SignalR: NSObject, UIWebViewDelegate {
 #if COCOAPODS
         let bundle = NSBundle(identifier: "org.cocoapods.SwiftR")!
 #else
-        let bundle = NSBundle(identifier: "com.adamhartford.SwiftR")!
+        let bundle = NSBundle.mainBundle()
 #endif
         let jqueryURL = bundle.URLForResource("jquery-2.1.3.min", withExtension: "js")!
         let signalRURL = bundle.URLForResource("jquery.signalR-2.2.0.min", withExtension: "js")!


### PR DESCRIPTION
The bundle id was hardcoded. However, other projects that are not using CocoaPods, have to use their own bundle id.