### PR TITLE
修改如果没有参数，调用JS后方法不会有回调

### DIFF
--- a/SwiftR/SwiftR.swift
+++ b/SwiftR/SwiftR.swift
@@ -430,7 +430,15 @@ public class Hub {
         
         let doneJS = "function() { postMessage({ message: 'invokeHandler', hub: '\(name.lowercaseString)', id: '\(uuid)', result: arguments[0] }); }"
         let failJS = "function() { postMessage({ message: 'invokeHandler', hub: '\(name.lowercaseString)', id: '\(uuid)', error: processError(arguments[0]) }); }"
-        let js = "swiftR.hubs.\(name).invoke('\(method)', \(args)).done(\(doneJS)).fail(\(failJS))"
+               var js = ""
+        
+//        if(args.isEmpty){
+//             js = "swiftR.hubs.\(name).invoke('\(method)').done(\(doneJS)).fail(\(failJS))"
+//        }else{
+//             js = "swiftR.hubs.\(name).invoke('\(method)', \(args)).done(\(doneJS)).fail(\(failJS))"
+//        }
+//
+        js = args.isEmpty ? "swiftR.hubs.\(name).invoke('\(method)').done(\(doneJS)).fail(\(failJS))":"swiftR.hubs.\(name).invoke('\(method)', \(args)).done(\(doneJS)).fail(\(failJS))"
         
         connection.runJavaScript(js)
     }


### PR DESCRIPTION
在这里做了个判断，如果传过来的参数为空，就调用不上传参数的方法。
Here to make a judgment, if the parameter is empty, it calls the method does not upload parameters.

SwiftR/SwiftR.swift
  var js = ""
        
//        if(args.isEmpty){
//             js = "swiftR.hubs.\(name).invoke('\(method)').done(\(doneJS)).fail(\(failJS))"
//        }else{
//             js = "swiftR.hubs.\(name).invoke('\(method)', \(args)).done(\(doneJS)).fail(\(failJS))"
//        }
//
        js = args.isEmpty ? "swiftR.hubs.\(name).invoke('\(method)').done(\(doneJS)).fail(\(failJS))":"swiftR.hubs.\(name).invoke('\(method)', \(args)).done(\(doneJS)).fail(\(failJS))"


PeterZ With ME