### PR TITLE
Change the 'error' can not identify by if

### DIFF
--- a/SwiftR/SwiftR.swift
+++ b/SwiftR/SwiftR.swift
@@ -378,7 +378,8 @@ public class SignalR: NSObject, SwiftRWebDelegate {
                     if let callback = hub.invokeHandlers[uuid] {
                         callback(result: result, error: error)
                         hub.invokeHandlers.removeValueForKey(uuid)
-                    } else if let e = error {
+                    } else if  (String(error) != "nil") {
+                        let e = error
                         print("SwiftR invoke error: \(e)")
                     }
                 }


### PR DESCRIPTION
Change the 'error' can not identify by if

SwiftR line 375 to 385

may there is a bug in swift—— if the parameters‘s type are AnyObject and the value is 'nil' , the if judgement not work.