### PR TITLE
Added basic compatibility for Objective-C.

### DIFF
--- a/SwiftR/SwiftR.swift
+++ b/SwiftR/SwiftR.swift
@@ -9,12 +9,12 @@
 import Foundation
 import WebKit
 
-public enum ConnectionType {
+@objc public enum ConnectionType: Int {
     case hub
     case persistent
 }
 
-public enum State {
+@objc public enum State: Int {
     case connecting
     case connected
     case disconnected
@@ -462,7 +462,7 @@ open class SignalR: NSObject, SwiftRWebDelegate {
 
 // MARK: - Hub
 
-open class Hub {
+open class Hub: NSObject {
     let name: String
     var handlers: [String: [String: ([Any]?) -> ()]] = [:]
     var invokeHandlers: [String: (_ result: Any?, _ error: AnyObject?) -> ()] = [:]


### PR DESCRIPTION
To get the library to properly generate a usable Swift header I made these changes. These changes are necessary to be compatible with Objective-C. More information is available in the Apple documentation: https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html

This is the bare minimum required to be able to work with this library from Objective-C in my experience.