### PR TITLE
Add configurable origin to enable fine-grained CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ app.UseCors (CorsOptions.AllowAll);
 // See my SignalRApplication repo for a CORS example with ASP.NET Core.
 ```
 
+#### How to set Origin
+
+In case allowing all origins (`*`) is not acceptable, you must configure the client via `originUrlString` property.
+
+```swift
+connection.originUrlString = "http://www.example.com"
+```
+
 ### What versions of SignalR are supported?
 
 SwiftR supports SignalR version 2.x. Version 2.2.1 is assumed by default. To change the SignalR version:


### PR DESCRIPTION
# Why
In case allowing all origins (`*`) is not acceptable the browser needs to send `Origin` header with a configured URL. 

# How it works
The default behavior is not changed. When the `originUrlString` property is set, the library will put all scripts in the HTML and load it from the origin url as specified.

# Tests
The signalR server used in the demo doesn't work for me. I used a local server to verify the changes for iOS. 