### PR TITLE
Swift 4.2 support - UIWebView.NavigationType enum

### DIFF
--- a/SwiftR/SwiftR.swift
+++ b/SwiftR/SwiftR.swift
@@ -447,7 +447,7 @@ open class SignalR: NSObject, SwiftRWebDelegate {
     // MARK: - Web delegate methods
     
 #if os(iOS)
-    open func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+    open func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebView.NavigationType) -> Bool {
         return shouldHandleRequest(request)
     }
 #else


### PR DESCRIPTION
While trying to build a project in XCode 10.1 - that uses SwiftR - there was a single compiler error trying to build the SwiftR cocoapod.
This pull request contains the single change required to get SwiftR up and running.

thanks,
Rich
